### PR TITLE
Show images under https only

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Also you can specify a image url to post with `image_url`
 
     lgtm.check_lgtm image_url: 'https://yourimage'
 
+If you want a https image only, you can use `https_image_only` option
+
+    lgtm.check_lgtm https_image_only: true
+
 ## Development
 
 1. Clone this repo

--- a/lib/lgtm/plugin.rb
+++ b/lib/lgtm/plugin.rb
@@ -16,7 +16,7 @@ module Danger
   # @tags lgtm, github
   #
   class DangerLgtm < Plugin
-    RANDOM_LGTM_POST_URL = 'http://lgtm.in/g'.freeze
+    RANDOM_LGTM_POST_URL = 'https://lgtm.in/g'.freeze
 
     # Check status report, say lgtm if no violations
     # Generates a `markdown` of a lgtm iamge.
@@ -57,7 +57,9 @@ module Danger
 
       yield req if block_given?
 
-      Net::HTTP.start(uri.hostname, uri.port) { |http| http.request(req) }
+      Net::HTTP.start(uri.hostname, uri.port, :use_ssl => true) do |http|
+        http.request(req)
+      end 
     end
 
     def markdown_template(image_url)

--- a/lib/lgtm/plugin.rb
+++ b/lib/lgtm/plugin.rb
@@ -47,7 +47,9 @@ module Danger
 
       lgtm_post = JSON.parse(lgtm_post_response.body)
 
-      lgtm_post['actualImageUrl']
+      url = lgtm_post['actualImageUrl']
+      return fetch_image_url unless URI.parse(url).scheme == 'https'
+      url
     end
 
     def process_request(url)

--- a/lib/lgtm/plugin.rb
+++ b/lib/lgtm/plugin.rb
@@ -19,7 +19,7 @@ module Danger
     RANDOM_LGTM_POST_URL = 'https://lgtm.in/g'.freeze
 
     # Check status report, say lgtm if no violations
-    # Generates a `markdown` of a lgtm iamge.
+    # Generates a `markdown` of a lgtm image.
     #
     # @param   [image_url] lgtm image url
     # @param   [https_image_only] fetching https image only if true

--- a/lib/lgtm/plugin.rb
+++ b/lib/lgtm/plugin.rb
@@ -59,9 +59,9 @@ module Danger
 
       yield req if block_given?
 
-      Net::HTTP.start(uri.hostname, uri.port, :use_ssl => true) do |http|
+      Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
         http.request(req)
-      end 
+      end
     end
 
     def markdown_template(image_url)

--- a/spec/lgtm_spec.rb
+++ b/spec/lgtm_spec.rb
@@ -25,17 +25,29 @@ module Danger
         expect(@dangerfile.status_report[:markdowns].length).to eq(1)
       end
 
-      it 'pick random pic from lgtm.in' do
-        mock = double(
-          :[] => 'https://lgtm.in/p/sSuI4hm0q',
+      def mock(request_url: 'https://lgtm.in/p/sSuI4hm0q',
+               actual_image_url: 'https://example.com/image.jpg')
+        double(
+          :[] => request_url,
           body: JSON.generate(
-            actualImageUrl: 'https://example.com/image.jpg'
+            actualImageUrl: actual_image_url
           )
         )
+      end
 
+      it 'pick random pic from lgtm.in' do
         allow(Net::HTTP).to receive(:start).and_return(mock)
 
         @lgtm.check_lgtm
+
+        expect(@dangerfile.status_report[:markdowns][0].message)
+          .to match(%r{https:\/\/example.com\/image.jpg})
+      end
+
+      it 'pick random pic from lgtm.in with https_image_only option' do
+        allow(Net::HTTP).to receive(:start).and_return(mock)
+
+        @lgtm.check_lgtm https_image_only: true
 
         expect(@dangerfile.status_report[:markdowns][0].message)
           .to match(%r{https:\/\/example.com\/image.jpg})


### PR DESCRIPTION
Hi!

This is a cool plugin! :sunglasses:

I want to display LGTM images under https.
So, I wanna retry fetching an image if the url of the fetching image is not https.

How do you think about this change?