### PR TITLE
503 handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-lgtm (1.0.1)
+    danger-lgtm (1.0.2)
       danger-plugin-api (~> 1.0)
 
 GEM
@@ -19,7 +19,7 @@ GEM
     colored2 (3.1.2)
     cork (0.3.0)
       colored2 (~> 3.1)
-    danger (5.6.2)
+    danger (5.6.4)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)

--- a/lib/lgtm/gem_version.rb
+++ b/lib/lgtm/gem_version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lgtm
-  VERSION = '1.0.1'.freeze
+  VERSION = '1.0.2'.freeze
 end

--- a/lib/lgtm/plugin.rb
+++ b/lib/lgtm/plugin.rb
@@ -40,7 +40,9 @@ module Danger
     private
 
     def fetch_image_url(https_image_only: false)
-      lgtm_post_url = process_request(RANDOM_LGTM_POST_URL)['location']
+      lgtm_post_req = process_request(RANDOM_LGTM_POST_URL)
+      return if lgtm_post_req.code == '503' # returns "img tag src='#'" when Service Temporarily Unavailable; Over Quota.
+      lgtm_post_url = lgtm_post_req['location']
 
       lgtm_post_response = process_request(lgtm_post_url) do |req|
         req['Accept'] = 'application/json'
@@ -68,7 +70,7 @@ module Danger
     end
 
     def markdown_template(image_url)
-      "<p align='center'><img src='#{image_url}' alt='LGTM' /></p>"
+      "<p align='center'><img src='#{(image_url || '#')}' alt='LGTM' /></p>"
     end
   end
 end

--- a/lib/lgtm/plugin.rb
+++ b/lib/lgtm/plugin.rb
@@ -39,11 +39,9 @@ module Danger
 
     private
 
+    # returns "<h1 align="center">LGTM</h1>" when ServiceTemporarilyUnavailable.
     def fetch_image_url(https_image_only: false)
-      lgtm_post_req = process_request(RANDOM_LGTM_POST_URL)
-      return if lgtm_post_req.code == '503' # returns "<h1 align="center">LGTM</h1>" when Service Temporarily Unavailable; Over Quota.
-      lgtm_post_url = lgtm_post_req['location']
-
+      return unless lgtm_post_url
       lgtm_post_response = process_request(lgtm_post_url) do |req|
         req['Accept'] = 'application/json'
       end
@@ -67,6 +65,12 @@ module Danger
       Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
         http.request(req)
       end
+    end
+
+    def lgtm_post_url
+      lgtm_post_req = process_request(RANDOM_LGTM_POST_URL)
+      return if lgtm_post_req.code == '503'
+      lgtm_post_req['location']
     end
 
     def markdown_template(image_url)

--- a/lib/lgtm/plugin.rb
+++ b/lib/lgtm/plugin.rb
@@ -41,7 +41,7 @@ module Danger
 
     def fetch_image_url(https_image_only: false)
       lgtm_post_req = process_request(RANDOM_LGTM_POST_URL)
-      return if lgtm_post_req.code == '503' # returns "img tag src='#'" when Service Temporarily Unavailable; Over Quota.
+      return if lgtm_post_req.code == '503' # returns "<h1 align="center">LGTM</h1>" when Service Temporarily Unavailable; Over Quota.
       lgtm_post_url = lgtm_post_req['location']
 
       lgtm_post_response = process_request(lgtm_post_url) do |req|
@@ -70,7 +70,11 @@ module Danger
     end
 
     def markdown_template(image_url)
-      "<p align='center'><img src='#{(image_url || '#')}' alt='LGTM' /></p>"
+      if image_url.nil?
+        "<h1 align='center'>LGTM</h1>"
+      else
+        "<p align='center'><img src='#{image_url}' alt='LGTM' /></p>"
+      end
     end
   end
 end

--- a/spec/lgtm_spec.rb
+++ b/spec/lgtm_spec.rb
@@ -25,13 +25,21 @@ module Danger
         expect(@dangerfile.status_report[:markdowns].length).to eq(1)
       end
 
+      it 'lgtm with default url is OverQuota' do
+        allow(Net::HTTP).to receive(:start).and_return(mock(code: '503'))
+
+        expect(@dangerfile.status_report[:markdowns]).to be_empty
+      end
+
       def mock(request_url: 'https://lgtm.in/p/sSuI4hm0q',
-               actual_image_url: 'https://example.com/image.jpg')
+               actual_image_url: 'https://example.com/image.jpg',
+               code: '200')
         double(
           :[] => request_url,
           body: JSON.generate(
             actualImageUrl: actual_image_url
-          )
+          ),
+          code: code
         )
       end
 

--- a/spec/lgtm_spec.rb
+++ b/spec/lgtm_spec.rb
@@ -24,11 +24,11 @@ module Danger
         @lgtm.check_lgtm
         expect(@dangerfile.status_report[:markdowns].length).to eq(1)
       end
-
       it 'lgtm with default url is OverQuota' do
         allow(Net::HTTP).to receive(:start).and_return(mock(code: '503'))
-
-        expect(@dangerfile.status_report[:markdowns]).to be_empty
+        @lgtm.check_lgtm
+        expect(@dangerfile.status_report[:markdowns][0].message)
+          .to eq("<h1 align='center'>LGTM</h1>")
       end
 
       def mock(request_url: 'https://lgtm.in/p/sSuI4hm0q',

--- a/spec/lgtm_spec.rb
+++ b/spec/lgtm_spec.rb
@@ -24,16 +24,19 @@ module Danger
         @lgtm.check_lgtm
         expect(@dangerfile.status_report[:markdowns].length).to eq(1)
       end
+
       it 'lgtm with default url is OverQuota' do
         allow(Net::HTTP).to receive(:start).and_return(mock(code: '503'))
+
         @lgtm.check_lgtm
+
         expect(@dangerfile.status_report[:markdowns][0].message)
           .to eq("<h1 align='center'>LGTM</h1>")
       end
 
       def mock(request_url: 'https://lgtm.in/p/sSuI4hm0q',
                actual_image_url: 'https://example.com/image.jpg',
-               code: '200')
+               code: '302')
         double(
           :[] => request_url,
           body: JSON.generate(


### PR DESCRIPTION
## Overview

https://lgtm.in/g returned 503.

<img width="891" alt="screen shot 2018-07-31 at 16 27 07" src="https://user-images.githubusercontent.com/12677991/43444452-b6e78e0c-94de-11e8-9f6c-aa44859fd85c.png">

I corresponded.

when https://www.lgtm.in/ returns 503, displays the html of the following.

```html
<h1 align='center'>LGTM</h1>
```

## Example

<h1 align='center'>LGTM</h1>