### PR TITLE
fix LoadError - cannot load such file -- ./lib/lgtm/errors

### DIFF
--- a/lib/lgtm/plugin.rb
+++ b/lib/lgtm/plugin.rb
@@ -3,8 +3,8 @@
 require 'uri'
 require 'json'
 require 'net/http'
-require './lib/lgtm/errors'
-require './lib/lgtm/error_handleable'
+require_relative 'errors'
+require_relative 'error_handleable'
 
 module Danger
   # Lgtm let danger say lgtm when there is no violations.


### PR DESCRIPTION
## Overview
Thank you for great plugin!
But, I found a problem.

I'm using Danger and this plugin on my jenkins.
But Danger failed to load this plugin with below error log.
```
Error loading the plugin `danger-lgtm-1.0.3`.
LoadError - cannot load such file -- ./lib/lgtm/errors
```

This PR will be fix this problem.

## Remarks
My friend using Circle.CI faced the same problem.
Also, I found who faced the same problem in Twitter.
Therefore, I think this problem is not depend on my CI environment.
But I have no idea why other people does not face this problem.